### PR TITLE
add IsTaxRegistered

### DIFF
--- a/Saasu.API.Core/Models/FileIdentity/FileIdentityDetail.cs
+++ b/Saasu.API.Core/Models/FileIdentity/FileIdentityDetail.cs
@@ -77,6 +77,12 @@
         /// Currency code of the payment eg: AUD or USD.
         /// </summary>
         public string CurrencyCode { get; set; }
+
+        /// <summary>
+        /// Is the business registered for tax or not(eg: GST, VAT).
+        /// </summary>
+        public bool IsTaxRegistered { get; set; }        
+
         /// <summary>
         /// Settings that specify the default behaviour for a file.
         /// </summary>


### PR DESCRIPTION
The api exposed field IsTaxRegistered: boolean but the SDK is missing it.
https://api.saasu.com/Help/Api/GET-FileIdentity

This field is necessary to determine the "purchase type" list for gst and non-gst client.
